### PR TITLE
Share ratio fixed to percentage instead of numeric ratio

### DIFF
--- a/app/scripts/services/torrentfactory.js
+++ b/app/scripts/services/torrentfactory.js
@@ -92,7 +92,7 @@ angular.module('ngTorrentUiApp')
             this.percent = percent;
             this.downloaded = downloaded;
             this.uploaded = uploaded;
-            this.ratio = (ratio/1000).toFixed(2);
+            this.ratio = (ratio/10).toFixed(2);
             this.uploadSpeed = uploadSpeed;
             this.downloadSpeed = downloadSpeed;
             this.eta = eta;


### PR DESCRIPTION
Percentage is consistent with UI.  It is much harder to remote the percent sign in dozens of files.  So fixed to actual percentage (was previously off by a factor of 100)
